### PR TITLE
Linux compilation fixes

### DIFF
--- a/Source/CsbBuilder/CsbBuilder.csproj
+++ b/Source/CsbBuilder/CsbBuilder.csproj
@@ -235,7 +235,7 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy "$(SolutionDir)Dependencies\*.dll" "$(TargetDir)"</PostBuildEvent>
+    <PostBuildEvent>copy "$(SolutionDir)Dependencies\*.dll" "$(TargetDir)" || find "$(SolutionDir)Dependencies/" -name "*.dll" -exec cp {} "$(TargetDir)" ";"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/SonicAudioLib/SonicAudioLib.csproj
+++ b/Source/SonicAudioLib/SonicAudioLib.csproj
@@ -68,7 +68,7 @@
     <Compile Include="IO\DataExtractor.cs" />
     <Compile Include="IO\StringPool.cs" />
     <Compile Include="Helpers.cs" />
-    <Compile Include="IO\SubStream.cs" />
+    <Compile Include="IO\Substream.cs" />
     <Compile Include="IO\DataPool.cs" />
     <Compile Include="FileBases\FileBase.cs" />
     <Compile Include="ProgressChangedEvent.cs" />


### PR DESCRIPTION
Enter these commands to build:
```
nuget restore SonicAudioTools.sln
msbuild SonicAudioTools.sln /p:Configuration=Release
```

Change log:
* Fixed word case in `SonicAudioLib.csproj`
* Added bash alternative of PostBuild script in `CsbBuilder.csproj`