### PR TITLE
Add OPUS & M4A encode types.

### DIFF
--- a/Source/AcbEditor/Program.cs
+++ b/Source/AcbEditor/Program.cs
@@ -418,6 +418,8 @@ namespace AcbEditor
                     return ".xma";
                 case 13:
                     return ".dsp";
+                case 24:
+                    return ".lopus";
                 default:
                     return ".bin";
             }

--- a/Source/AcbEditor/Program.cs
+++ b/Source/AcbEditor/Program.cs
@@ -404,20 +404,22 @@ namespace AcbEditor
                     return ".dsadpcm";
                 case 6:
                     return ".hcamx";
-                case 10:
                 case 7:
+                case 10:
                     return ".vag";
                 case 8:
                     return ".at3";
                 case 9:
                     return ".bcwav";
-                case 18:
                 case 11:
+                case 18:
                     return ".at9";
                 case 12:
                     return ".xma";
                 case 13:
                     return ".dsp";
+                case 19:
+                    return ".m4a";
                 case 24:
                     return ".lopus";
                 default:


### PR DESCRIPTION
OPUS uses a fake extension (lopus), but all the encoding and decoding software for this opus container use this extension anyway so might as well.

M4A is checked from vgmstream code.
https://github.com/vgmstream/vgmstream/blob/479117fbc2251e5083c3dfd65597f31372021ba5/src/meta/awb.c#L124

Also minor rearranging of the cases.